### PR TITLE
Pin version of nf-validation and nf-iridanext #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release of fetchdatairidanext pipeline which will download reads from NCBI/INSDC archives.
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2024-02-22
+
+### Changed
+
+- Pinned nf-validation (@1.1.3) and nf-iridanext (@0.2.0) plugins to specific versions in nextflow.config
+
 ## [1.0.0] - 2024-01-26
 
 ### Added
 
 - Initial release of fetchdatairidanext pipeline which will download reads from NCBI/INSDC archives.
 
-## [1.0.1] - 2024-02-22
 
-### Changed
-
-- Pinned nf-validation (@1.1.3) and nf-iridanext (@0.2.0) plugins to specific versions in nextflow.config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release of fetchdatairidanext pipeline which will download reads from NCBI/INSDC archives.
+
+## [1.0.1] - 2024-02-22
+
+### Changed
+
+- Pinned nf-validation (@1.1.3) and nf-iridanext (@0.2.0) plugins to specific versions in nextflow.config

--- a/nextflow.config
+++ b/nextflow.config
@@ -155,8 +155,8 @@ singularity.registry = 'quay.io'
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation' // Validation of pipeline parameters and creation of an input channel from a sample sheet
-    id 'nf-iridanext'
+    id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-iridanext@0.2.0'
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
@@ -198,7 +198,7 @@ manifest {
     description     = """IRIDA Next pipeline for fetching data from NCBI"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.0.0'
+    version         = '1.0.1'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
…tflow.config file

<!--
# phac-nml/fetchdatairidanext pull request

Many thanks for contributing to phac-nml/fetchdatairidanext!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/phac-nml/fetchdatairidanext/tree/main/.github/CONTRIBUTING.md)
-->

This PR is linked to the following issue: Pin version of nf-validation and nf-iridanext #11

This PR pins two Nextflow plugins to specific versions in the nextflow.config file:
- nf-validation@1.1.3
- nf-iridanext@0.2.0

This change was required due to an upcoming upgrade of the nf-validation plugin from 1.1.3 to 2.0.0 which will make breaking changes (https://github.com/nextflow-io/plugins/pull/66).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

