### PR TITLE
Increased resources to process_medium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2025-02-28
+
+### `Changed`
+
+- Switched `SRATOOLS_FASTERQDUMP` and `FASTQ_DL` resources to `process_medium` to increase resources (storage space) in our deployment for downloading large datasets in [PR #26](https://github.com/phac-nml/fetchdatairidanext/pull/26).
+
 ## [1.3.1] - 2025-02-28
 
 ### `Changed`
@@ -66,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of fetchdatairidanext pipeline which will download reads from NCBI/INSDC archives.
 
+[1.3.2]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.3.1
 [1.3.1]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.3.1
 [1.3.0]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.3.0
 [1.2.0]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- Switched `SRATOOLS_FASTERQDUMP` and `FASTQ_DL` resources to `process_medium` to increase resources (storage space) in our deployment for downloading large datasets in [PR #26](https://github.com/phac-nml/fetchdatairidanext/pull/26).
+- Switched `SRATOOLS_FASTERQDUMP` and `FASTQ_DL` resources to `process_medium` to increase resources (storage space) in our deployment for downloading large datasets in [PR #27](https://github.com/phac-nml/fetchdatairidanext/pull/27).
 
 ## [1.3.1] - 2025-02-28
 
@@ -72,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of fetchdatairidanext pipeline which will download reads from NCBI/INSDC archives.
 
-[1.3.2]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.3.1
+[1.3.2]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.3.2
 [1.3.1]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.3.1
 [1.3.0]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.3.0
 [1.2.0]: https://github.com/phac-nml/fetchdatairidanext/releases/tag/1.2.0

--- a/modules/local/fastq_dl/main.nf
+++ b/modules/local/fastq_dl/main.nf
@@ -1,6 +1,6 @@
 process FASTQ_DL {
     tag "$id"
-    label 'process_single'
+    label 'process_medium'
 
     conda "bioconda::fastq-dl=3.0.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/sratools/fasterqdump/main.nf
+++ b/modules/local/sratools/fasterqdump/main.nf
@@ -1,6 +1,6 @@
 process SRATOOLS_FASTERQDUMP {
     tag "$meta.id"
-    label 'process_low'
+    label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/nextflow.config
+++ b/nextflow.config
@@ -205,7 +205,7 @@ manifest {
     description     = """IRIDA Next pipeline for fetching data from INSDC Databases"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.3.1'
+    version         = '1.3.2'
     doi             = ''
     defaultBranch   = 'main'
 }


### PR DESCRIPTION
Increases resources to `process_medium` for downloading/extracting fastqs to avoid running out of storage space.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
