### PR TITLE
STRY0019104 - Test against GSP version of Nextflow in GitHub CI for all pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       matrix:
         NXF_VER:
           - "23.04.0"
-          - "23.10.1"
-          #- "latest-everything"
+          - "24.10.3"
+          - "latest-everything"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v3
@@ -52,9 +52,11 @@ jobs:
           sudo mv nf-test /usr/local/bin/
 
       - name: Run nf-test
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nf-test test
 
       - name: Nextflow run with test profile
+        continue-on-error: ${{ matrix.NXF_VER == 'latest-everything' }}
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### `Changed`
+
+- Adding GitHub CI tests against Nextflow `24.10.3`. [PR #28](https://github.com/phac-nml/fetchdatairidanext/pull/28)
+
 ## [1.3.2] - 2025-02-28
 
 ### `Changed`


### PR DESCRIPTION
Adding GitHub CI tests against Nextflow `24.10.3`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.